### PR TITLE
Fix lingon logging

### DIFF
--- a/lib/lingon-livereload.js
+++ b/lib/lingon-livereload.js
@@ -32,6 +32,6 @@ module.exports = function(lingon, config) {
 
     server.watch(config.watchDir);
 
-    lingon.log('Livereload is listening on port ' + config.port);
+    lingon.log.info('Livereload is listening on port ' + config.port);
   });
 };


### PR DESCRIPTION
`lingon.log` is not a function since it was changed to `lingon.log.info` and `lingon.log.error`