### PR TITLE
Fixed that host is sent as parameter to connect-livereload-safe

### DIFF
--- a/lib/lingon-livereload.js
+++ b/lib/lingon-livereload.js
@@ -10,10 +10,11 @@ module.exports = function(lingon, config) {
 
     config = config || {};
     config.port = config.port || 35729;
+    config.host = config.host || 'localhost';
 
     // inject browser script tag
     lingon.server.use(connectLr({
-      port: config.port
+      host: 'http://' + config.host + ':' + config.port
     }));
   });
 


### PR DESCRIPTION
Fixed that .host is sent as parameter to connect-livereload-safe which doesn't understand .port
